### PR TITLE
gemspec: update rubocop version marker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in ecraft-web-dsl-builtins.gemspec
 gemspec

--- a/ecraft-extensions.gemspec
+++ b/ecraft-extensions.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-rspec', '~> 4.7'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop', '~> 0.47'
+  spec.add_development_dependency 'rubocop', '~> 0.51'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
This PR updates RuboCop version in the gemspec in order to make the warning from GitHub go away.

It also drops a misleading comment.