### PR TITLE
Remove all.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This code contains some useful extension methods to various Ruby classes.
 
-It also contains a few mixins in the `Ecraft::Extensions::Mixins` module.
+It also contains a mixin in the `Ecraft::Extensions::Mixins` module.
 
 ## Installation
 
@@ -24,25 +24,20 @@ Or install it yourself as:
 
 ## Usage
 
-Preferred approach:
-
 ```ruby
 # To load a specific extension:
 require 'ecraft/extensions/bigdecimal'
 ```
 
-Not-so-preferred approach:
-
-```ruby
- # To load _all_ core extensions. USE WITH GREAT CARE, since this could cause conflicts with other libraries.
-require 'ecraft/extensions/all'
-```
-
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+After checking out the repo, run `bin/setup` to install dependencies.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+Then, run `rake spec` to run the tests.
+
+You can also run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 ## Contributing
 
@@ -52,29 +47,27 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/ecraft
 
 We strive to write documentation inline in [YARD](http://yardoc.org) format.
 
-### Previewing documentation locally
+### Preview documentation locally
+
 ```
 bundle exec yard server -r
 ```
 
-Check the locally served documentation at http://localhost:8808/
+Check the locally served documentation at [http://localhost:8808/](http://localhost:8808/).
 
 ### Releasing a new version
 
 - Bump the version in `version.rb`
 - Create the tag:
-
   ```
-  $ git release v1.0.x`
+  $ git release v1.0.x
   ```
-
-- Build the gemfile and push it to Rubygems.org:
-
+- Build the `.gem` file and push it to Rubygems.org:
   ```shell
   $ bundle exec rake build release
   ```
-
-- Generate the changelog (`cargo install changelog-rs && changelog-rs .`) and copy the relevant lines to [the releases page](https://github.com/ecraft/ecraft-extensions/releases).
+- Generate the changelog (`cargo install changelog-rs && changelog-rs .`) and
+  copy the relevant lines to [the releases page](https://github.com/ecraft/ecraft-extensions/releases).
 
 ### License
 

--- a/bin/console
+++ b/bin/console
@@ -9,8 +9,16 @@ Bundler.require
 $LOAD_PATH << "./lib"
 
 require 'ecraft/extensions'
-require 'ecraft/extensions/all'
+require 'ecraft/extensions/bigdecimal'
+require 'ecraft/extensions/date'
+require 'ecraft/extensions/datetime'
+require 'ecraft/extensions/ostruct'
+require 'ecraft/extensions/string'
+require 'ecraft/extensions/time'
 
-puts "<#{$PROGRAM_NAME}> Starting IRB with ecraft/extensions/all"
+puts "<#{$PROGRAM_NAME}> Starting IRB with each file in ecraft/extensions/ required"
+puts
+puts "<#{$PROGRAM_NAME}> To try the mixin, require 'ecraft/extensions/mixins/hashable'"
+
 
 IRB.start

--- a/bin/console
+++ b/bin/console
@@ -20,5 +20,4 @@ puts "<#{$PROGRAM_NAME}> Starting IRB with each file in ecraft/extensions/ requi
 puts
 puts "<#{$PROGRAM_NAME}> To try the mixin, require 'ecraft/extensions/mixins/hashable'"
 
-
 IRB.start

--- a/lib/ecraft/extensions/all.rb
+++ b/lib/ecraft/extensions/all.rb
@@ -1,7 +1,0 @@
-# Requiring this file will activate _all_ the "core extensions" defined in ecraft-extensions. This may or may not be what you want.
-# It is usually a better, safer approach to selectively require only the parts you know that you need, since core extensions _can_
-# potentially cause conflicts with other libraries extending core classes (such as ActiveSupport).
-require 'ecraft/extensions/bigdecimal'
-require 'ecraft/extensions/date'
-require 'ecraft/extensions/datetime'
-require 'ecraft/extensions/ostruct'


### PR DESCRIPTION
This PR adds notes about what isn't included in "all" when you require the "all.rb".