### PR TITLE
Fix Travis build failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,5 @@ before_install:
  - rm -rf ~/.rvm && if [ ! -d "$HOME/jruby-bin" ]; then mkdir -p ~/jruby-bin && pushd ~/jruby-bin && curl -o- -L https://s3.amazonaws.com/jruby.org/downloads/9.1.15.0/jruby-bin-9.1.15.0.tar.gz | tar xzf - --strip-components=1 && popd ; fi
  - export PATH="$HOME/jruby-bin/bin:$PATH"
  - gem install bundler
- - gem update --system
 
 cache: bundler


### PR DESCRIPTION
This makes the build be green again. The previous approach causes the builds to fail on Bundler 1.16.1.

Upstream issue: https://github.com/rubygems/rubygems/issues/2123

(Rubygems 2.7.4 still doesn't seem to fix the problem in its entirety.)