### PR TITLE
CI: Update JRuby download URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
  - "JRUBY_OPTS=--debug"
 
 before_install:
- - rm -rf ~/.rvm && if [ ! -d "$HOME/jruby-bin" ]; then mkdir -p ~/jruby-bin && pushd ~/jruby-bin && curl -o- -L https://s3.amazonaws.com/jruby.org/downloads/9.1.15.0/jruby-bin-9.1.15.0.tar.gz | tar xzf - --strip-components=1 && popd ; fi
+ - rm -rf ~/.rvm && if [ ! -d "$HOME/jruby-bin" ]; then mkdir -p ~/jruby-bin && pushd ~/jruby-bin && curl -o- -L https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.1.15.0/jruby-dist-9.1.15.0-bin.tar.gz | tar xzf - --strip-components=1 && popd ; fi
  - export PATH="$HOME/jruby-bin/bin:$PATH"
  - gem install bundler
 


### PR DESCRIPTION
This PR updates the JRuby download URL.

This fixes the build.
